### PR TITLE
Enable filtering by an arbitrary task string

### DIFF
--- a/src/ArchiverSettingTab.ts
+++ b/src/ArchiverSettingTab.ts
@@ -1,7 +1,12 @@
 import { App, PluginSettingTab, Setting } from "obsidian";
 
 import ObsidianTaskArchiver from "./ObsidianTaskArchiverPlugin";
+import {
+    DEFAULT_COMPLETED_TASK_PATTERN,
+    DEFAULT_TASK_PATTERN,
+} from "./Patterns";
 
+import {setTaskPattern} from "./Util"
 export class ArchiverSettingTab extends PluginSettingTab {
     constructor(app: App, private plugin: ObsidianTaskArchiver) {
         super(app, plugin);
@@ -146,6 +151,19 @@ export class ArchiverSettingTab extends PluginSettingTab {
                     });
                 });
         }
+
+        new Setting(containerEl)
+            .setName("Task pattern")
+            .setDesc("Only archive tasks matching this pattern, typically '#task' but can be anything.")
+            .addText((textComponent) => {
+                    textComponent
+                        .setValue(this.plugin.settings.taskPattern)
+                        .onChange(async (value) => {
+                             this.plugin.settings.taskPattern = value;
+                             setTaskPattern(value);
+                            await this.plugin.saveSettings();
+                        }); 
+                });
 
         new Setting(containerEl)
             .setName("Use days")

--- a/src/ObsidianTaskArchiverPlugin.ts
+++ b/src/ObsidianTaskArchiverPlugin.ts
@@ -9,6 +9,7 @@ import { ListToHeadingTransformer } from "./features/ListToHeadingTransformer";
 import { TaskListSorter } from "./features/TaskListSorter";
 import { BlockParser } from "./parser/BlockParser";
 import { SectionParser } from "./parser/SectionParser";
+import { setTaskPattern } from "./Util";
 
 async function withNotice(cb: () => Promise<string>) {
     try {
@@ -30,6 +31,7 @@ export default class ObsidianTaskArchiver extends Plugin {
 
     async onload() {
         await this.loadSettings();
+        setTaskPattern(this.settings.taskPattern);
         this.addSettingTab(new ArchiverSettingTab(this.app, this));
 
         this.parser = new SectionParser(

--- a/src/Patterns.ts
+++ b/src/Patterns.ts
@@ -5,5 +5,5 @@ export const HEADING_PATTERN = /^(#+)(\s.*)$/;
 const BULLET_SIGN = `(?:[-*+]|\\d+\\.)`;
 export const LIST_ITEM_PATTERN = new RegExp(`^[ \t]*${BULLET_SIGN}( |\t)`);
 export const STRING_WITH_SPACES_PATTERN = new RegExp(`^[ \t]+`);
-export const TASK_PATTERN = new RegExp(`^${BULLET_SIGN} \\[[x ]]`);
-export const COMPLETED_TASK_PATTERN = new RegExp(`^${BULLET_SIGN} \\[x]`);
+export const DEFAULT_TASK_PATTERN = `^${BULLET_SIGN} \\[[x ]]`;
+export const DEFAULT_COMPLETED_TASK_PATTERN = `^${BULLET_SIGN} \\[x]`;

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -11,6 +11,7 @@ export interface Settings {
     dailyNoteFormat: string;
     useDays: boolean;
     indentationSettings: IndentationSettings;
+    taskPattern: string; 
     addNewlinesAroundHeadings: boolean;
     archiveToSeparateFile: boolean;
     defaultArchiveFileName: string;
@@ -23,6 +24,7 @@ export const DEFAULT_SETTINGS: Settings = {
     useWeeks: true,
     dailyNoteFormat: "YYYY-MM-DD",
     useDays: false,
+    taskPattern: "", 
     addNewlinesAroundHeadings: true,
     archiveToSeparateFile: false,
     defaultArchiveFileName: "% (archive)",

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -5,14 +5,19 @@ import { flow, isEmpty, last, partition } from "lodash";
 import { dropRightWhile, dropWhile } from "lodash/fp";
 
 import {
-    COMPLETED_TASK_PATTERN,
     HEADING_PATTERN,
     INDENTATION_PATTERN,
     LIST_ITEM_PATTERN,
     STRING_WITH_SPACES_PATTERN,
-    TASK_PATTERN,
+    DEFAULT_COMPLETED_TASK_PATTERN,
+    DEFAULT_TASK_PATTERN,
 } from "./Patterns";
+
+let taskPattern = new RegExp(DEFAULT_TASK_PATTERN);
+let completedTaskPattern = new RegExp(DEFAULT_COMPLETED_TASK_PATTERN);
+
 import { IndentationSettings } from "./Settings";
+import { Settings } from "./Settings";
 import { Block } from "./model/Block";
 import { Section } from "./model/Section";
 import { TextBlock } from "./model/TextBlock";
@@ -50,12 +55,16 @@ function findBlockRecursivelyInCollection(
     return null;
 }
 
+export function setTaskPattern(pattern: string) {
+    taskPattern = new RegExp(DEFAULT_TASK_PATTERN + ".*" + pattern);
+    completedTaskPattern = new RegExp(DEFAULT_COMPLETED_TASK_PATTERN +  ".*" + pattern); 
+}
 export function isCompletedTask(line: string) {
-    return COMPLETED_TASK_PATTERN.test(line);
+    return completedTaskPattern.test(line);
 }
 
 function isTask(line: string) {
-    return TASK_PATTERN.test(line);
+    return taskPattern.test(line);
 }
 
 export function sortBlocksRecursively(root: Block) {


### PR DESCRIPTION
See issue 16 https://github.com/ivan-lednev/obsidian-task-archiver/issues/16 for what this solves.  

I have managed to enable a new preference called "Task Pattern" in the plugin.  
Let's say you have four tasks in your file as follows: 
```markdown
## Test Cases 
- [ ] Task 1
- [x] Task 2 is completed SHOULD NOT BE ARCHIVED
- [ ] #task #context/test Task 3 is real and not completed
- [x] #task Task 4 is real and  completed
```
If you set your Task pattern to be "#task" as in this picture: 
![2022-07-20 13 58 16 CleanShot Obsidian](https://user-images.githubusercontent.com/4825448/180081290-2b92dd06-80d5-4711-a4f5-87534928c475.png)

Then when can use the "Archiver: Archive Tasks..." command, it would only archive Task 4 because it is completed and has the `#task` pattern in it.  

I do not think I have done a good job with Javascript encapsulation or code format protocols, so sorry about that.  Im just pushing this to offer up a feature which I would find very useful. 