### PR TITLE
Prevent outdated settings

### DIFF
--- a/src/ObsidianTaskArchiverPlugin.ts
+++ b/src/ObsidianTaskArchiverPlugin.ts
@@ -109,6 +109,7 @@ export default class ObsidianTaskArchiver extends Plugin {
 
     async saveSettings() {
         await this.saveData(this.settings);
+        await this.loadSettings();
     }
 
     private createCheckCallbackForPreviewAndEditView(


### PR DESCRIPTION
Prevent having to restart Obsidian or re-load the plug-in after updating the settings for them to take effect.