### PR TITLE
Fix incorrect archiving of unmatched incomplete tasks

### DIFF
--- a/src/ObsidianTaskArchiverPlugin.ts
+++ b/src/ObsidianTaskArchiverPlugin.ts
@@ -144,7 +144,7 @@ export default class ObsidianTaskArchiver extends Plugin {
         const parser = new SectionParser(
             new BlockParser(this.settings.indentationSettings)
         );
-        const taskTestingService = new TaskTestingService(this.settings);
+        const taskTestingService = new TaskTestingService(this.app.workspace, this.settings);
         const placeholderService = new PlaceholderService(this.app.workspace);
         const listItemService = new ListItemService(placeholderService, this.settings);
         const textReplacementService = new TextReplacementService(this.settings);

--- a/src/features/ArchiveFeature.ts
+++ b/src/features/ArchiveFeature.ts
@@ -41,8 +41,7 @@ import {
 } from "../util/CodeMirrorUtil";
 import { getDailyNotePath } from "../util/DailyNotes";
 import {
-    doesRuleMatchTaskStatus,
-    doesStringOfPatternsMatchText,
+    doesRuleMatch,
     isRuleActionValid,
 } from "../util/RuleUtil";
 import {
@@ -153,14 +152,7 @@ export class ArchiveFeature {
     private findRuleForTask(task: Block) {
         return (
             this.settings.rules.find(
-                (rule) =>
-                    doesStringOfPatternsMatchText(
-                        rule.pathPatterns,
-                        this.workspace.getActiveFile().path
-                    ) &&
-                    doesStringOfPatternsMatchText(rule.textPatterns, task.text) &&
-                    doesRuleMatchTaskStatus(rule, task) &&
-                    isRuleActionValid(rule)
+                (rule) => doesRuleMatch(rule, task, this.workspace) && isRuleActionValid(rule)
             ) || createDefaultRule(this.settings)
         );
     }

--- a/src/features/__tests__/test-util/TestUtil.js
+++ b/src/features/__tests__/test-util/TestUtil.js
@@ -53,7 +53,7 @@ export class TestDependencies {
         this.sectionParser = new SectionParser(
             new BlockParser(settings.indentationSettings)
         );
-        this.taskTestingService = new TaskTestingService(settings);
+        this.taskTestingService = new TaskTestingService(this.mockWorkspace, settings);
         this.placeholderService = new PlaceholderService(this.mockWorkspace);
         this.listItemService = new ListItemService(this.placeholderService, settings);
         this.textReplacementService = new TextReplacementService(settings);

--- a/src/util/RuleUtil.ts
+++ b/src/util/RuleUtil.ts
@@ -1,3 +1,5 @@
+import { Workspace } from "obsidian";
+
 import { isEmpty } from "lodash/fp";
 
 import { Rule, RuleAction } from "../Settings";
@@ -32,4 +34,10 @@ export function isRuleActionValid(rule: Rule) {
         rule.defaultArchiveFileName.trim().length > 0 ||
         rule.ruleAction === RuleAction.DELETE
     );
+}
+
+export function doesRuleMatch(rule: Rule, task: Block, workspace: Workspace) {
+    return doesRuleMatchTaskStatus(rule, task) &&
+        doesStringOfPatternsMatchText(rule.pathPatterns, workspace.getActiveFile().path) &&
+        doesStringOfPatternsMatchText(rule.textPatterns, task.text);
 }

--- a/src/util/RuleUtil.ts
+++ b/src/util/RuleUtil.ts
@@ -11,7 +11,7 @@ function getTaskStatus(task: Block) {
     return taskStatus;
 }
 
-export function doesRuleMatchTaskStatus(rule: Rule, task: Block) {
+function doesRuleMatchTaskStatus(rule: Rule, task: Block) {
     if (rule.statuses) {
         return rule.statuses.includes(getTaskStatus(task));
     }
@@ -19,7 +19,7 @@ export function doesRuleMatchTaskStatus(rule: Rule, task: Block) {
     return !DEFAULT_INCOMPLETE_TASK_PATTERN.test(task.text);
 }
 
-export function doesStringOfPatternsMatchText(patterns: string, text: string) {
+function doesStringOfPatternsMatchText(patterns: string, text: string) {
     if (isEmpty(patterns)) {
         return true;
     }

--- a/src/util/RuleUtil.ts
+++ b/src/util/RuleUtil.ts
@@ -4,6 +4,7 @@ import { isEmpty } from "lodash/fp";
 
 import { Rule, RuleAction } from "../Settings";
 import { Block } from "../model/Block";
+import { DEFAULT_INCOMPLETE_TASK_PATTERN } from "../Patterns";
 
 function getTaskStatus(task: Block) {
     const [, taskStatus] = task.text.match(/\[(.)]/);
@@ -11,11 +12,11 @@ function getTaskStatus(task: Block) {
 }
 
 export function doesRuleMatchTaskStatus(rule: Rule, task: Block) {
-    if (isEmpty(rule.statuses)) {
-        return true;
+    if (rule.statuses) {
+        return rule.statuses.includes(getTaskStatus(task));
     }
 
-    return rule.statuses.includes(getTaskStatus(task));
+    return !DEFAULT_INCOMPLETE_TASK_PATTERN.test(task.text);
 }
 
 export function doesStringOfPatternsMatchText(patterns: string, text: string) {


### PR DESCRIPTION
Resolves #88 (The problem is detailed in this issue)

## Changes Made
- Make `doesRuleMatch` function for a more consistent rule evaluation throughout the application. (https://github.com/ivan-lednev/obsidian-task-archiver/commit/a31011be218e8d4e3a709af52e306f4fe464b9ab)
   - `ArchiveFeature`, `TaskTestService` use this new integrated function (https://github.com/ivan-lednev/obsidian-task-archiver/commit/cbe47208668a3fb7e39473b544d6f38a6875aa23, https://github.com/ivan-lednev/obsidian-task-archiver/commit/f5aedf21632a0b55b2e141fc12cf23e655d859fb)
- Modified the logic in doesRuleMatchTaskStatus function to ensure that it accurately checks (https://github.com/ivan-lednev/obsidian-task-archiver/commit/426f122d2ac0257d2ab9ea799936eb371c35785a)

## Additional Information
- Please review the updated function and feature implementation for any potential impacts on other areas of the application.
- I am open to feedback and will earnestly incorporate any suggestions or improvements recommended during the review process. 😄