### PR TITLE
Fix indentation corruption when useTab is true but file contains spaces

### DIFF
--- a/src/features/__tests__/ArchiveFeature.test.js
+++ b/src/features/__tests__/ArchiveFeature.test.js
@@ -1293,6 +1293,34 @@ describe("Archive only if subtasks are done", () => {
         );
     });
 
+    test("Handles space-indented nested tasks correctly when useTab is true", async () => {
+        await archiveTasksAndCheckActiveFile(
+            [
+                "- [x] parent",
+                "    - [x] child 1",
+                "        - [x] grandchild",
+                "    - [x] child 2",
+                "# Archived",
+                "",
+            ],
+            [
+                "# Archived",
+                "",
+                "- [x] parent",
+                "\t- [x] child 1",
+                "\t\t- [x] grandchild",
+                "\t- [x] child 2",
+                "",
+            ],
+            {
+                settings: {
+                    ...DEFAULT_SETTINGS_FOR_TESTS,
+                    archiveOnlyIfSubtasksAreDone: true,
+                },
+            }
+        );
+    });
+
     test("Archives completed task if it has sub-items with bullets", async () => {
         await archiveTasksAndCheckActiveFile(
             ["- [x] foo", "\t- bar", "\t- [x] baz", "# Archived", ""],

--- a/src/services/parser/BlockParser.ts
+++ b/src/services/parser/BlockParser.ts
@@ -49,11 +49,18 @@ export class BlockParser {
         // TODO: this needs to be 1 only because the root block is 0, but this way this knowledge is implicit
         const [indentation] = splitOnIndentation(line);
         const levelsOfIndentation = 1;
-        if (this.settings.useTab) {
-            return levelsOfIndentation + indentation.length;
+
+        let effectiveWidth = 0;
+        for (const ch of indentation) {
+            if (ch === "\t") {
+                effectiveWidth += this.settings.tabSize;
+            } else {
+                effectiveWidth++;
+            }
         }
+
         return (
-            levelsOfIndentation + Math.ceil(indentation.length / this.settings.tabSize)
+            levelsOfIndentation + Math.ceil(effectiveWidth / this.settings.tabSize)
         );
     }
 

--- a/src/services/parser/BlockParser.ts
+++ b/src/services/parser/BlockParser.ts
@@ -50,17 +50,18 @@ export class BlockParser {
         const [indentation] = splitOnIndentation(line);
         const levelsOfIndentation = 1;
 
-        let effectiveWidth = 0;
+        let column = 0;
         for (const ch of indentation) {
             if (ch === "\t") {
-                effectiveWidth += this.settings.tabSize;
+                // Advance to the next tab stop
+                column = Math.ceil((column + 1) / this.settings.tabSize) * this.settings.tabSize;
             } else {
-                effectiveWidth++;
+                column++;
             }
         }
 
         return (
-            levelsOfIndentation + Math.ceil(effectiveWidth / this.settings.tabSize)
+            levelsOfIndentation + Math.ceil(column / this.settings.tabSize)
         );
     }
 

--- a/src/services/parser/__tests__/SectionParser.test.js
+++ b/src/services/parser/__tests__/SectionParser.test.js
@@ -171,6 +171,26 @@ describe("List items", () => {
         expect(nestedListItem.children.length).toBe(1);
     });
 
+    test("Multiple list items on different levels with spaces and useTab: true", () => {
+        const lines = [
+            "- 1",
+            "    - 1a",
+            "        - 1a1",
+            "            - 1a1a",
+            "    - 1b",
+        ];
+
+        const doc = new SectionParser(
+            new BlockParser({
+                useTab: true,
+                tabSize: 4,
+            })
+        ).parse(lines);
+        expect(doc.blockContent.children.length).toBe(1);
+        const item1 = doc.blockContent.children[0];
+        expect(item1.children.length).toBe(2); // "1a" and "1b" should be siblings
+    });
+
     test("Handles misaligned lists", () => {
         const lines = ["- l", "  - text"];
 
@@ -236,6 +256,25 @@ describe("Stringification", () => {
         const parsed = new SectionParser(new BlockParser(settings)).parse(lines);
         const stringified = parsed.stringify(buildIndentation(settings));
         expect(stringified).toEqual(lines);
+    });
+
+    test("Round-tripping with space-indented content and useTab: true converts to tabs correctly", () => {
+        const lines = [
+            "- 1",
+            "    - 1a",
+            "        - 1a1",
+            "    - 1b",
+        ];
+
+        const settings = { useTab: true, tabSize: 4 };
+        const parsed = new SectionParser(new BlockParser(settings)).parse(lines);
+        const stringified = parsed.stringify(buildIndentation(settings));
+        expect(stringified).toEqual([
+            "- 1",
+            "\t- 1a",
+            "\t\t- 1a1",
+            "\t- 1b",
+        ]);
     });
 
     test("Round-tripping does not mess up code blocks", () => {

--- a/src/services/parser/__tests__/SectionParser.test.js
+++ b/src/services/parser/__tests__/SectionParser.test.js
@@ -191,6 +191,40 @@ describe("List items", () => {
         expect(item1.children.length).toBe(2); // "1a" and "1b" should be siblings
     });
 
+    test("Mixed spaces and tabs uses tab-stop semantics", () => {
+        const parser = new BlockParser({ useTab: true, tabSize: 4 });
+
+        // "  \t" = 2 spaces + tab to next stop = column 4 = 1 indent level
+        expect(parser.getIndentationLevel("  \t- item")).toBe(2);
+        // "\t" = tab to column 4 = 1 indent level
+        expect(parser.getIndentationLevel("\t- item")).toBe(2);
+        // "   \t" = 3 spaces + tab to column 4 = 1 indent level (same as plain tab)
+        expect(parser.getIndentationLevel("   \t- item")).toBe(2);
+        // "\t\t" = tab to 4, tab to 8 = 2 indent levels
+        expect(parser.getIndentationLevel("\t\t- item")).toBe(3);
+        // "    \t" = 4 spaces (already at tab stop) + tab to column 8 = 2 indent levels
+        expect(parser.getIndentationLevel("    \t- item")).toBe(3);
+    });
+
+    test("Tab-indented input with useTab: false parses levels correctly", () => {
+        const lines = [
+            "- 1",
+            "\t- 1a",
+            "\t\t- 1a1",
+            "\t- 1b",
+        ];
+
+        const doc = new SectionParser(
+            new BlockParser({
+                useTab: false,
+                tabSize: 4,
+            })
+        ).parse(lines);
+        expect(doc.blockContent.children.length).toBe(1);
+        const item1 = doc.blockContent.children[0];
+        expect(item1.children.length).toBe(2); // "1a" and "1b" should be siblings
+    });
+
     test("Handles misaligned lists", () => {
         const lines = ["- l", "  - text"];
 


### PR DESCRIPTION
## Summary
- Fix `getIndentationLevel` in `BlockParser.ts` counting each character individually instead of computing effective indentation width
- When `useTab` was true and the file contained space-based indentation (e.g., 4 spaces), levels were inflated (level 5 instead of level 2), causing progressively deeper indentation in the output
- Use proper tab-stop semantics for mixed whitespace (a tab advances to the next multiple of `tabSize`, matching editor behavior)
- **Behavioral change**: parsing is now content-based regardless of `useTab` — the parser interprets whatever indentation is actually in the file. `useTab` only affects output formatting. Previously, `useTab: true` assumed each indentation character was a tab, and `useTab: false` divided raw character count by `tabSize`, both of which broke for mismatched input.

Fixes #108

## Test plan
- [x] Added tests for round-tripping space-indented content with `useTab: true`
- [x] Added tests for archiving with `useTab` and space-indented source
- [x] Added tests asserting exact indentation levels for mixed tabs+spaces (tab-stop semantics)
- [x] Added test for tab-indented input with `useTab: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)