### PR TITLE
fix: Make the completion date pattern compatible with Dataview

### DIFF
--- a/src/Patterns.ts
+++ b/src/Patterns.ts
@@ -24,6 +24,6 @@ export const DEFAULT_INCOMPLETE_TASK_PATTERN = new RegExp(
 
 export const CHECKED_TASK_PATTERN = new RegExp(`${BULLET_SIGN} ${CHECKBOX_CHECKED}`);
 
-export const OBSIDIAN_TASKS_COMPLETED_DATE_PATTERN = /✅ (\d{4}-\d{2}-\d{2})/;
+export const OBSIDIAN_TASKS_COMPLETED_DATE_PATTERN = /✅ ?(\d{4}-\d{2}-\d{2})/;
 
 export const FILE_EXTENSION_PATTERN = /\.\w+$/;


### PR DESCRIPTION
The `obsidian-tasks` plugin expects a space after the ✅ (e.g. `✅ 2023-03-29`) while the [Obsidian Dataview](https://blacksmithgu.github.io/obsidian-dataview/) plugin does not. Make it so that we detect both ways of writing the completion date, as their meaning is equivalent.